### PR TITLE
Added sprite data for temporary game character Shoe and added partial draw sprite logic

### DIFF
--- a/src/DrawingUtils.asm
+++ b/src/DrawingUtils.asm
@@ -186,13 +186,97 @@ _draw_sprite_attributes_row_decrement:
 ;
 ; ------------------------------------------------------------------------------
 draw_title_screen:
-	ld de,341               ; title screen has 341 lines of encoded byte pairs
-	ld hl,title_screen_data ; get the location of the encoded data
-	ld ix,0x4000            ; start drawing at the beginning of the vram
-_draw_title_screen_loop_start:
-	call copy_encoded_bytes ; unpack first encoded byte pair
-	dec de                  ; decrement our byte pair counter
-	ld a,d                  ; check if counter is 0, we do it this way because
-	or e                    ;   our counter needs to work for a value above 255
-	jp nz,_draw_title_screen_loop_start
+
+	; TODO: ADD TITLE GRAPHIC AT TOP
+
+	; DRAW ARROWS AROUND P1
+	ld de,0x48e1
+	ld a,(left_arrow)
+	call print_char
+
+	ld de,0x48e8
+	ld a,(right_arrow)
+	call print_char
+
+
+	; DRAW ARROWS AROUND P2
+	ld de,0x48f7
+	ld a,(left_arrow)
+	call print_char
+
+	ld de,0x48fe
+	ld a,(right_arrow)
+	call print_char
+
+
+	; INSTRUCTIONS
+	ld de,0x50a2
+	ld ix,character_select_instructions_1
+	ld c,29
+	call print_string
+
+	ld de,0x50e6
+	ld ix,character_select_instructions_2
+	ld c,20
+	call print_string
+
+	ret
+
+; ------------------------------------------------------------------------------
+; Subroutine for drawing the sprite and name of characters onto the character
+;   select screen.
+;
+; Inputs:
+;
+; Outputs:
+;
+; ------------------------------------------------------------------------------
+
+draw_title_character_p1:
+	ld a,(selected_character_p1)
+	call ld_character_data_address
+	ld c,10
+	ld de,0x5040
+	call print_string
+	ld d,6
+	ld c,0
+	ld hl,0x4882
+	jp draw_sprite
+
+draw_title_character_p2:
+  ld a,(selected_character_p2)
+  call ld_character_data_address
+  ld c,10
+  ld de,0x5056
+  call print_string
+  ld d,6
+  ld c,0
+  ld hl,0x4898
+	jp draw_sprite
+
+
+; ------------------------------------------------------------------------------
+; This routine is basically a switch statement for determining which character
+; is selected based on the character index passed in through A, and loading
+; the address of that character's data into IX. This can't be done by storing
+; pointers to the data in memory, because IX can only be loaded with constants
+;
+; Inputs:
+;   A  = Index of the character whose data address should be loaded
+; Outputs:
+;   IX = Address of the data of the character
+; ------------------------------------------------------------------------------
+ld_character_data_address:
+	inc a
+	sub 1
+	jp z,_ld_character_data_address_char_0
+	sub 1
+	jp z,_ld_character_data_address_char_1
+_ld_character_data_address_char_0:
+	ld ix,shoe_data
+	jp _ld_character_data_address_done
+_ld_character_data_address_char_1:
+	ld ix,sprite_data
+	jp _ld_character_data_address_done
+_ld_character_data_address_done:
 	ret

--- a/src/GameData.asm
+++ b/src/GameData.asm
@@ -1,355 +1,16 @@
-; Encoded data of the format x,y repeated, where x is the byte to write into
-; VRAM and y is the number of times to write it
-title_screen_data:
-	defb 0,193
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,194
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,194
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,194
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,194
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,194
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,194
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,194
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,67
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,3
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,67
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,3
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,67
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,3
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,67
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,3
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,67
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,3
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,67
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,3
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,67
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,3
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,2
-	defb 255,30
-	defb 0,67
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,35
-	defb 255,8
-	defb 0,14
-	defb 255,8
-	defb 0,35
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,35
-	defb 255,8
-	defb 0,14
-	defb 255,8
-	defb 0,35
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,35
-	defb 255,8
-	defb 0,14
-	defb 255,8
-	defb 0,35
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,35
-	defb 255,8
-	defb 0,14
-	defb 255,8
-	defb 0,35
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,35
-	defb 255,8
-	defb 0,14
-	defb 255,8
-	defb 0,35
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,35
-	defb 255,8
-	defb 0,14
-	defb 255,8
-	defb 0,35
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,35
-	defb 255,8
-	defb 0,14
-	defb 255,8
-	defb 0,35
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,4
-	defb 255,6
-	defb 0,16
-	defb 255,6
-	defb 0,35
-	defb 255,8
-	defb 0,14
-	defb 255,8
-	defb 0,33
-	defb 71,255
-	defb 71,255
-	defb 71,255
-	defb 71,4
-
-
+character_select_instructions_1:
+	defb 'A/D & J/L to select character'
+character_select_instructions_2:
+	defb 'Press Enter to start'
+left_arrow:
+	defb '<'
+right_arrow:
+	defb '>'
 
 ; Character data looks like:
 ; struct character {
 ;   <name>_name - 10 bytes
-;   <name>_sprite_pixels - 6x6 sprite of pixel data
-;   <name>_sprite_attributes - 6x6 worth of attribute bytes
+;   <name>_sprite_data - 6x6 pixel bytes followed by corresponding attributes
 ; }
 shoe_data:
 shoe_name:
@@ -447,115 +108,201 @@ shoe_sprite_attributes:
 	defb 71,7
 	defb 0,0
 
-lambtron_data:
-lambtron_name:
-	defb ' Lambtron '
 
 sprite_data:
 sprite_name:
 	defb '  Sprite  '
 
 sprite_sprite_data:
-	defb 0,17
+	defb 0,20
 	defb 7,1
 	defb 224,1
-	defb 0,2
+	defb 0,4
 	defb 8,1
 	defb 16,1
-	defb 0,2
+	defb 0,4
 	defb 8,1
 	defb 16,1
-	defb 0,2
+	defb 0,4
+	defb 8,1
+	defb 16,1
+	defb 0,4
 	defb 15,1
 	defb 240,1
-	defb 0,2
+	defb 0,4
 	defb 8,1
 	defb 16,1
-	defb 0,2
+	defb 0,4
 	defb 8,1
 	defb 16,1
-	defb 0,2
-	defb 8,1
-	defb 16,1
-	defb 0,2
-	defb 16,1
-	defb 8,1
-	defb 0,2
-	defb 32,1
-	defb 4,1
-	defb 0,2
-	defb 64,1
-	defb 2,1
-	defb 0,2
-	defb 128,1
-	defb 1,1
-	defb 0,1
+	defb 0,4
+	defb 48,1
+	defb 12,1
+	defb 0,4
+	defb 192,1
+	defb 3,1
+	defb 0,3
 	defb 1,1
 	defb 0,2
 	defb 128,1
+	defb 0,2
 	defb 2,1
 	defb 0,2
 	defb 64,1
+	defb 0,2
 	defb 4,1
 	defb 0,2
 	defb 32,1
-	defb 5,1
+	defb 0,2
+	defb 4,1
+	defb 0,2
+	defb 32,1
+	defb 0,2
+	defb 8,1
+	defb 0,2
+	defb 16,1
+	defb 0,2
+	defb 8,1
+	defb 0,2
+	defb 16,1
+	defb 0,2
+	defb 16,1
+	defb 0,2
+	defb 8,1
+	defb 0,2
+	defb 16,1
+	defb 0,2
+	defb 8,1
+	defb 0,2
+	defb 16,1
+	defb 0,2
+	defb 8,1
+	defb 0,2
+	defb 16,1
+	defb 0,2
+	defb 8,1
+	defb 0,2
+	defb 16,1
+	defb 0,2
+	defb 8,1
+	defb 0,2
+	defb 31,1
+	defb 255,2
+	defb 248,1
+	defb 0,2
+	defb 16,1
+	defb 0,2
+	defb 8,1
+	defb 0,2
+	defb 16,1
+	defb 0,2
+	defb 8,1
+	defb 0,2
+	defb 17,1
 	defb 128,1
 	defb 72,1
-	defb 160,1
-	defb 6,1
+	defb 136,1
+	defb 0,2
+	defb 18,1
 	defb 17,1
 	defb 29,1
-	defb 96,1
-	defb 5,1
+	defb 72,1
+	defb 0,2
+	defb 17,1
 	defb 42,1
 	defb 73,1
-	defb 160,1
-	defb 4,1
+	defb 136,1
+	defb 0,2
+	defb 16,1
 	defb 178,1
 	defb 73,1
-	defb 32,1
-	defb 7,1
+	defb 8,1
+	defb 0,2
+	defb 19,1
 	defb 34,1
 	defb 72,1
-	defb 224,1
-	defb 4,1
+	defb 200,1
 	defb 0,2
-	defb 32,1
-	defb 4,1
+	defb 16,1
 	defb 0,2
-	defb 32,1
-	defb 4,1
+	defb 8,1
 	defb 0,2
-	defb 32,1
-	defb 4,1
+	defb 31,1
+	defb 255,2
+	defb 248,1
 	defb 0,2
-	defb 32,1
-	defb 4,1
+	defb 16,1
 	defb 0,2
-	defb 32,1
-	defb 4,1
+	defb 8,1
 	defb 0,2
-	defb 32,1
-	defb 4,1
+	defb 16,1
 	defb 0,2
-	defb 32,1
-	defb 4,1
-	defb 49,1
-	defb 140,1
-	defb 32,1
-	defb 3,1
-	defb 206,1
-	defb 115,1
-	defb 192,1
+	defb 8,1
+	defb 0,2
+	defb 16,1
+	defb 0,2
+	defb 8,1
+	defb 0,2
+	defb 16,1
+	defb 0,2
+	defb 8,1
+	defb 0,2
+	defb 16,1
+	defb 0,2
+	defb 8,1
+	defb 0,2
+	defb 16,1
+	defb 0,2
+	defb 8,1
+	defb 0,2
+	defb 16,1
+	defb 0,2
+	defb 8,1
+	defb 0,2
+	defb 16,1
+	defb 0,2
+	defb 8,1
+	defb 0,2
+	defb 16,1
+	defb 0,2
+	defb 8,1
+	defb 0,2
+	defb 16,1
+	defb 0,2
+	defb 8,1
+	defb 0,2
+	defb 16,1
+	defb 0,2
+	defb 8,1
+	defb 0,2
+	defb 16,1
+	defb 0,2
+	defb 8,1
+	defb 0,2
+	defb 16,1
+	defb 0,2
+	defb 8,1
+	defb 0,2
+	defb 9,1
+	defb 153,2
+	defb 144,1
+	defb 0,2
+	defb 6,1
+	defb 102,2
+	defb 96,1
+	defb 0,1
 	defb 0,0
 sprite_sprite_attributes:
-	defb 42,4
-	defb 44,4
-	defb 40,4
-	defb 44,4
+	defb 120,36
 	defb 0,0
 
 ; 2 bytes of memory reserved for storing screen addresses in draw routines
 draw_memory_store:
-defb 0,0
+	defb 0,0
+
+selected_character_p1:
+	defb 0
+selected_character_p2:
+	defb 1
+selected_character_max:
+	defb 1

--- a/src/PrintingUtils.asm
+++ b/src/PrintingUtils.asm
@@ -42,25 +42,3 @@ print_char:
 	ld b,8           ; copy all 8 bytes in the character bitmap
 	call copy_bytes  ; copy bitmap to vram
 	ret
-
-
-; ------------------------------------------------------------------------------
-; Subroutines for printing character names to the title screen
-;
-; Inputs:
-;		IX = Address of the name to print
-; Outputs:
-;
-; ------------------------------------------------------------------------------
-print_p1_name_title_screen:
-	ld de,0x50c0
-	jp print_name_title_screen
-
-print_p2_name_title_screen:
-	ld de,0x50d6
-	jp print_name_title_screen
-
-print_name_title_screen:
-	ld c,10
-	call print_string
-	ret

--- a/src/main.asm
+++ b/src/main.asm
@@ -6,52 +6,18 @@ start:
 	di
 
 	; set border color
-	ld a,0                    ; blue
+	ld a,1                    ; blue
 	out (0xfe),a              ; send to ula
 
 	; fill screen with black
   ld hl,0x5800          ; address of first attribute byte
   ld bc,768             ; number of attribute bytes
-  ld d,7                ; 0b00000111  (paper = black, ink = white)
+  ld d,0x47             ; 0b00000111  (paper = black, ink = white)
   call fill_byte
 
-	; start title screen loop
-  ld b,2
-  ld c,9
-  call calculate_color_cell_pixel_address
-
-  ld d,6
-  ld c,0
-  ld ix,shoe_sprite_data
-  call draw_sprite
-
-  ld b,0
-  ld c,15
-  call calculate_color_cell_pixel_address
-  ld d,h
-  ld e,l
-
-  ld ix,shoe_name
-  call print_name_title_screen
-
-  ld b,24
-  ld c,9
-  call calculate_color_cell_pixel_address
-
-  ld d,4
-  ld c,0
-  ld ix,sprite_sprite_data
-  call draw_sprite
-
-  ld b,22
-  ld c,15
-  call calculate_color_cell_pixel_address
-  ld d,h
-  ld e,l
-
-  ld ix,sprite_name
-  call print_name_title_screen
-
+  call draw_title_screen
+  call draw_title_character_p1
+  call draw_title_character_p2
 
   include "src/ByteAddressUtils.asm"
   include "src/DrawingUtils.asm"


### PR DESCRIPTION
The current draw sprite logic does not handle blending, only correctly draws for specific values of IX, and needs work. I think it is a good start and would like to get it in the main branch so we can get used to main.asm having only real game logic and get more eyes on this draw code so we can get it perfect since it will be used all over the place.